### PR TITLE
Surppot status log which don't include resource log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,5 +47,6 @@ test:
 	grep "RCheckUCPU" /tmp/resource.log
 	grep "RCheckSCPU" /tmp/resource.log
 	grep "RCheckMEM" /tmp/resource.log
+	grep "RCheckSTATUS" /tmp/resource.log
 
 .PHONY: test

--- a/test/mod_resource_checker.conf
+++ b/test/mod_resource_checker.conf
@@ -8,4 +8,5 @@ RCheckLogPath /tmp/resource.log
     RCheckSCPU 0.00001 ALL
     RCheckUCPU 0.00001 ALL
     RCheckMEM  0.001 ALL
+    RCheckSTATUS On
 </VirtualHost>

--- a/test/mod_resource_checker.conf.2.4
+++ b/test/mod_resource_checker.conf.2.4
@@ -9,4 +9,5 @@ RCheckLogPath /tmp/resource.log
     RCheckSCPU 0.00001 ALL
     RCheckUCPU 0.00001 ALL
     RCheckMEM  0.001 ALL
+    RCheckSTATUS On
 </VirtualHost>

--- a/test/mod_resource_checker.conf.2.4.prefork
+++ b/test/mod_resource_checker.conf.2.4.prefork
@@ -9,4 +9,5 @@ RCheckLogPath /tmp/resource.log
     RCheckSCPU 0.00001 ALL
     RCheckUCPU 0.00001 ALL
     RCheckMEM  0.001 ALL
+    RCheckSTATUS On
 </VirtualHost>


### PR DESCRIPTION
for fluentd and norikra.

```
RCheckSTATUS On
```

- don't include resource log

```json
{
  "result": 0,
  "scheme": "http",
  "filename": "/var/www/html/index.html",
  "remote_ip": "127.0.0.1",
  "location": "/",
  "unit": "null",
  "type": "RCheckSTATUS",
  "date": "Thu Oct  8 13:14:04 2015",
  "module": "mod_resource_checker",
  "method": "GET",
  "hostname": "127.0.0.1",
  "uri": "/index.html",
  "uid": 0,
  "size": 7,
  "status": 200,
  "pid": 17860,
  "threshold": 0
}
```