### PR TITLE
Support all resource logging on one-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ LoadModule resource_checker_module modules/mod_resource_checker.so
     ```
     RCheckLogPath "/usr/local/apache/logs/resoruce.log"
     ```
-      
+
     or
 
-- if enable JSON Format `RCheckJSONFormat On`, for exmaple, 
+- if enable JSON Format `RCheckJSONFormat On`, for exmaple,
 
     ```
     RCheckLogPath "| mongoimport -d apache -c resource_check"
@@ -87,14 +87,66 @@ LoadModule resource_checker_module modules/mod_resource_checker.so
 }
 ```
 
-or below log format
+- Logging all status and resources log
 
 ```apache
-RCheckJSONFormat Off
+RCheckALL On
 ```
 
+```json
+{
+  "result": {
+    "RCheckMEM": 0,
+    "RCheckSCPU": 0,
+    "RCheckUCPU": 0.351562
+  },
+  "response_time": 0,
+  "scheme": "http",
+  "filename": "/var/www/html/index.html",
+  "remote_ip": "127.0.0.1",
+  "location": "/",
+  "unit": null,
+  "type": "RCheckALL",
+  "date": "Fri Oct  9 14:08:56 2015",
+  "module": "mod_resource_checker",
+  "method": "GET",
+  "hostname": "127.0.0.1",
+  "uri": "/index.html",
+  "uid": 0,
+  "size": 7,
+  "status": 200,
+  "pid": 15184,
+  "threshold": null
+}
 ```
-[Fri Apr 26 23:11:18 2013] pid=3225 RESOURCE_CHECKER: [ RCheckUCPU(sec) = 0.2969550000 (ALL) > threshold=(0.00001) ] config_dir=(/) src_ip=(192.168.12.1) access_file=(/usr/local/apache244/htdocs/blog/index.php) request=(GET /?p=3414 HTTP/1.0)
+
+- Logging all request which don't include resouces data
+
+```apache
+RCheckSTATUS On
+```
+
+```json
+{
+  "result": 0,
+  "response_time": 0,
+  "scheme": "http",
+  "filename": "/var/www/html/index.html",
+  "remote_ip": "127.0.0.1",
+  "location": "/",
+  "unit": "null",
+  "type": "RCheckSTATUS",
+  "date": "Fri Oct 09 15:43:26 2015",
+  "module": "mod_resource_checker",
+  "method": "GET",
+  "hostname": "127.0.0.1",
+  "uri": "/index.html",
+  "uid": 0,
+  "size": 7,
+  "status": 200,
+  "pid": 20572,
+  "threshold": 0
+}
 ```
 
 - Logging CPUUserTime

--- a/mod_resource_checker.c
+++ b/mod_resource_checker.c
@@ -183,8 +183,8 @@ void RESOURCE_CHECKER_DEBUG_SYSLOG(const char *key, const char *msg, pool *p)
 /* ------------------------------------------- */
 static double resource_checker_response_time(request_rec *r)
 {
-    apr_time_t duration = apr_time_now() - r->request_time;
-    return (double)apr_time_sec(duration);
+  apr_time_t duration = apr_time_now() - r->request_time;
+  return (double)apr_time_sec(duration);
 }
 
 static const char *ap_mrb_string_check(apr_pool_t *p, const char *str)
@@ -199,7 +199,8 @@ static const char *ap_mrb_string_check(apr_pool_t *p, const char *str)
   return str;
 }
 
-static void _mod_resource_checker_logging_all(request_rec *r, RESOURCE_DATA *data, RESOURCE_CHECKER_D_CONF *conf, ACCESS_INFO *info, apr_pool_t *p)
+static void _mod_resource_checker_logging_all(request_rec *r, RESOURCE_DATA *data, RESOURCE_CHECKER_D_CONF *conf,
+                                              ACCESS_INFO *info, apr_pool_t *p)
 {
   int len;
   time_t t;
@@ -219,12 +220,10 @@ static void _mod_resource_checker_logging_all(request_rec *r, RESOURCE_DATA *dat
   json_object_object_add(log_obj, "date", json_object_new_string(ap_mrb_string_check(r->pool, log_time)));
   json_object_object_add(log_obj, "type", json_object_new_string(ap_mrb_string_check(r->pool, "RCheckALL")));
   json_object_object_add(log_obj, "unit", NULL);
-  json_object_object_add(log_obj, "location",
-                         json_object_new_string(ap_mrb_string_check(r->pool, conf->target_dir)));
+  json_object_object_add(log_obj, "location", json_object_new_string(ap_mrb_string_check(r->pool, conf->target_dir)));
   json_object_object_add(log_obj, "remote_ip",
                          json_object_new_string(ap_mrb_string_check(r->pool, info->access_src_ip)));
-  json_object_object_add(log_obj, "filename",
-                         json_object_new_string(ap_mrb_string_check(r->pool, info->access_file)));
+  json_object_object_add(log_obj, "filename", json_object_new_string(ap_mrb_string_check(r->pool, info->access_file)));
   json_object_object_add(log_obj, "scheme", json_object_new_string(ap_mrb_string_check(r->pool, ap_http_scheme(r))));
   json_object_object_add(log_obj, "method", json_object_new_string(ap_mrb_string_check(r->pool, r->method)));
   json_object_object_add(log_obj, "hostname", json_object_new_string(ap_mrb_string_check(r->pool, r->hostname)));
@@ -879,7 +878,6 @@ static int after_resource_checker(request_rec *r)
     return DECLINED;
   }
 
-
   match = 0;
   pAnalysisResouceAfter->cpu_utime = INITIAL_VALUE;
   pAnalysisResouceAfter->cpu_stime = INITIAL_VALUE;
@@ -985,7 +983,6 @@ static int after_resource_checker(request_rec *r)
   if (pDirConf->check_all == ON && pDirConf->json_fmt == ON) {
     _mod_resource_checker_logging_all(r, pAnalysisResouceNow, pDirConf, pAccessInfoData, r->pool);
   }
-
 
 #ifdef __MOD_DEBUG__
   RESOURCE_CHECKER_DEBUG_SYSLOG("after_resource_checker: ", "end", r->pool);

--- a/mod_resource_checker.c
+++ b/mod_resource_checker.c
@@ -33,6 +33,7 @@
 #include "ap_config.h"
 #include "http_log.h"
 #include "apr_strings.h"
+#include "util_time.h"
 
 #include <unistd.h>
 #include <sys/types.h>
@@ -202,16 +203,11 @@ static const char *ap_mrb_string_check(apr_pool_t *p, const char *str)
 static void _mod_resource_checker_logging_all(request_rec *r, RESOURCE_DATA *data, RESOURCE_CHECKER_D_CONF *conf,
                                               ACCESS_INFO *info, apr_pool_t *p)
 {
-  int len;
-  time_t t;
-  char *log_time;
+  char log_time[APR_CTIME_LEN];
   char *mod_resource_checker_log_buf;
   json_object *log_obj, *result_obj;
 
-  time(&t);
-  log_time = (char *)ctime(&t);
-  len = strlen(log_time);
-  log_time[len - 1] = '\0';
+  ap_recent_ctime(log_time, r->request_time);
 
   log_obj = json_object_new_object();
   result_obj = json_object_new_object();
@@ -244,6 +240,9 @@ static void _mod_resource_checker_logging_all(request_rec *r, RESOURCE_DATA *dat
 
   apr_file_puts(mod_resource_checker_log_buf, mod_resource_checker_log_fp);
   apr_file_flush(mod_resource_checker_log_fp);
+
+  json_object_put(result_obj);
+  json_object_put(log_obj);
 }
 
 #ifdef __MOD_APACHE1__
@@ -258,22 +257,17 @@ static void _mod_resource_checker_logging(request_rec *r, double resource_time, 
                                               const char *unit, apr_pool_t *p)
 #endif
 {
-  int len;
-  time_t t;
-  char *log_time;
+  char log_time[APR_CTIME_LEN];
+  char *mod_resource_checker_log_buf;
+  json_object *log_obj = NULL;
 
 #ifdef __MOD_DEBUG__
   RESOURCE_CHECKER_DEBUG_SYSLOG("_mod_resource_checker_logging: ", "start", p);
 #endif
 
-  time(&t);
-  log_time = (char *)ctime(&t);
-  len = strlen(log_time);
-  log_time[len - 1] = '\0';
-  char *mod_resource_checker_log_buf;
+  ap_recent_ctime(log_time, r->request_time);
 
   if (pDirConf->json_fmt == ON) {
-    json_object *log_obj;
     log_obj = json_object_new_object();
     json_object_object_add(log_obj, "module", json_object_new_string(ap_mrb_string_check(r->pool, msg)));
     json_object_object_add(log_obj, "date", json_object_new_string(ap_mrb_string_check(r->pool, log_time)));
@@ -324,6 +318,9 @@ static void _mod_resource_checker_logging(request_rec *r, double resource_time, 
   apr_file_puts(mod_resource_checker_log_buf, mod_resource_checker_log_fp);
   apr_file_flush(mod_resource_checker_log_fp);
 #endif
+
+  if (log_obj != NULL)
+    json_object_put(log_obj);
 
 #ifdef __MOD_DEBUG__
   RESOURCE_CHECKER_DEBUG_SYSLOG("_mod_resource_checker_logging: ", "end", p);

--- a/mod_resource_checker.c
+++ b/mod_resource_checker.c
@@ -763,17 +763,26 @@ static int before_resource_checker(request_rec *r)
 
   if (pDirConf->cpu_utime > INITIAL_VALUE || pDirConf->check_all == ON) {
     match = 1;
-    pAnalysisResouceBefore->cpu_utime = _get_rusage_resource(r->pool, pDirConf->utime_process_type, "cpu_utime");
+    if (pDirConf->check_all == ON)
+      pAnalysisResouceBefore->cpu_utime = _get_rusage_resource(r->pool, "ALL", "cpu_utime");
+    else
+      pAnalysisResouceBefore->cpu_utime = _get_rusage_resource(r->pool, pDirConf->utime_process_type, "cpu_utime");
   }
 
   if (pDirConf->cpu_stime > INITIAL_VALUE || pDirConf->check_all == ON) {
     match = 1;
-    pAnalysisResouceBefore->cpu_stime = _get_rusage_resource(r->pool, pDirConf->stime_process_type, "cpu_stime");
+    if (pDirConf->check_all == ON)
+      pAnalysisResouceBefore->cpu_utime = _get_rusage_resource(r->pool, "ALL", "cpu_stime");
+    else
+      pAnalysisResouceBefore->cpu_stime = _get_rusage_resource(r->pool, pDirConf->stime_process_type, "cpu_stime");
   }
 
   if (pDirConf->shared_mem > INITIAL_VALUE || pDirConf->check_all == ON) {
     match = 1;
-    pAnalysisResouceBefore->shared_mem = _get_rusage_resource(r->pool, pDirConf->mem_process_type, "shared_mem");
+    if (pDirConf->check_all == ON)
+      pAnalysisResouceBefore->cpu_utime = _get_rusage_resource(r->pool, "ALL", "shared_mem");
+    else
+      pAnalysisResouceBefore->shared_mem = _get_rusage_resource(r->pool, pDirConf->mem_process_type, "shared_mem");
   }
 
   if (match == 0) {
@@ -878,17 +887,26 @@ static int after_resource_checker(request_rec *r)
 
   if (pDirConf->cpu_utime > INITIAL_VALUE || pDirConf->check_all == ON) {
     match = 1;
-    pAnalysisResouceAfter->cpu_utime = _get_rusage_resource(r->pool, pDirConf->utime_process_type, "cpu_utime");
+    if (pDirConf->check_all == ON)
+      pAnalysisResouceAfter->cpu_utime = _get_rusage_resource(r->pool, "ALL", "cpu_utime");
+    else
+      pAnalysisResouceAfter->cpu_utime = _get_rusage_resource(r->pool, pDirConf->utime_process_type, "cpu_utime");
   }
 
   if (pDirConf->cpu_stime > INITIAL_VALUE || pDirConf->check_all == ON) {
     match = 1;
-    pAnalysisResouceAfter->cpu_stime = _get_rusage_resource(r->pool, pDirConf->stime_process_type, "cpu_stime");
+    if (pDirConf->check_all == ON)
+      pAnalysisResouceAfter->cpu_utime = _get_rusage_resource(r->pool, "ALL", "cpu_stime");
+    else
+      pAnalysisResouceAfter->cpu_stime = _get_rusage_resource(r->pool, pDirConf->stime_process_type, "cpu_stime");
   }
 
   if (pDirConf->shared_mem > INITIAL_VALUE || pDirConf->check_all == ON) {
     match = 1;
-    pAnalysisResouceAfter->shared_mem = _get_rusage_resource(r->pool, pDirConf->mem_process_type, "shared_mem");
+    if (pDirConf->check_all == ON)
+      pAnalysisResouceAfter->cpu_utime = _get_rusage_resource(r->pool, "ALL", "shared_mem");
+    else
+      pAnalysisResouceAfter->shared_mem = _get_rusage_resource(r->pool, pDirConf->mem_process_type, "shared_mem");
   }
 
   if (match == 0) {

--- a/test/mod_resource_checker.conf
+++ b/test/mod_resource_checker.conf
@@ -9,4 +9,5 @@ RCheckLogPath /tmp/resource.log
     RCheckUCPU 0.00001 ALL
     RCheckMEM  0.001 ALL
     RCheckSTATUS On
+    RCheckALL On
 </VirtualHost>

--- a/test/mod_resource_checker.conf.2.4
+++ b/test/mod_resource_checker.conf.2.4
@@ -10,4 +10,5 @@ RCheckLogPath /tmp/resource.log
     RCheckUCPU 0.00001 ALL
     RCheckMEM  0.001 ALL
     RCheckSTATUS On
+    RCheckALL On
 </VirtualHost>

--- a/test/mod_resource_checker.conf.2.4.prefork
+++ b/test/mod_resource_checker.conf.2.4.prefork
@@ -10,4 +10,5 @@ RCheckLogPath /tmp/resource.log
     RCheckUCPU 0.00001 ALL
     RCheckMEM  0.001 ALL
     RCheckSTATUS On
+    RCheckALL On
 </VirtualHost>


### PR DESCRIPTION
```apache
LoadModule resource_checker_module modules/mod_resource_checker.so

<Location />
  RCheckALL On
</Location>
```

```json
$ echo '{ "module": "mod_resource_checker", "date": "Fri Oct  9 14:08:56 2015", "type": "RCheckALL", "unit": null, "location": "\/", "remote_ip": "127.0.0.1", "filename": "\/var\/www\/html\/index.html", "scheme": "http", "method": "GET", "hostname": "127.0.0.1", "uri": "\/index.html", "uid": 0, "size": 7, "status": 200, "pid": 15184, "threshold": null, "response_time": 0.000000, "result": { "RCheckUCPU": 0.351562, "RCheckSCPU": 0.000000, "RCheckMEM": 0.000000 } }
> ' | jq .
{
  "result": {
    "RCheckMEM": 0,
    "RCheckSCPU": 0,
    "RCheckUCPU": 0.351562
  },
  "response_time": 0,
  "scheme": "http",
  "filename": "/var/www/html/index.html",
  "remote_ip": "127.0.0.1",
  "location": "/",
  "unit": null,
  "type": "RCheckALL",
  "date": "Fri Oct  9 14:08:56 2015",
  "module": "mod_resource_checker",
  "method": "GET",
  "hostname": "127.0.0.1",
  "uri": "/index.html",
  "uid": 0,
  "size": 7,
  "status": 200,
  "pid": 15184,
  "threshold": null
}
```